### PR TITLE
调整了目录结构,将树莓派的串口驱动放在了drivers crate下面

### DIFF
--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -27,6 +27,9 @@ rcore-console = { git = "https://github.com/rcore-os/rcore-console", default-fea
 # smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp", rev = "35e833e3", default-features = false, features = ["log", "alloc", "verbose", "proto-ipv4", "proto-ipv6", "proto-igmp", "medium-ip", "medium-ethernet", "socket-raw", "socket-udp", "socket-tcp", "socket-icmp"] }
 smoltcp = { git = "https://gitee.com/gcyyfun/smoltcp", rev="043eb60", default-features = false, features = ["alloc","log", "async", "medium-ethernet","proto-ipv4", "proto-igmp", "socket-icmp", "socket-udp", "socket-tcp", "socket-raw"] }
 
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+tock-registers = "0.7"
+
 [target.'cfg(not(target_os = "none"))'.dependencies]
 async-std = { version = "1.10", optional = true }
 sdl2 = { version = "0.34", optional = true }

--- a/drivers/src/uart/mod.rs
+++ b/drivers/src/uart/mod.rs
@@ -2,9 +2,13 @@
 
 mod buffered;
 mod uart_16550;
+#[cfg(target_arch = "aarch64")]
+mod uart_pl011;
 
 pub use buffered::BufferedUart;
 pub use uart_16550::Uart16550Mmio;
 
 #[cfg(target_arch = "x86_64")]
 pub use uart_16550::Uart16550Pmio;
+#[cfg(target_arch = "aarch64")]
+pub use uart_pl011::Pl011Uart;

--- a/drivers/src/uart/uart_pl011.rs
+++ b/drivers/src/uart/uart_pl011.rs
@@ -2,10 +2,9 @@
 use tock_registers::interfaces::{Readable, Writeable};
 use tock_registers::register_structs;
 use tock_registers::registers::{ReadOnly, ReadWrite};
-use crate::imp::config::UART_ADDR;
-use zcore_drivers::scheme::{UartScheme, EventScheme, Scheme};
-use zcore_drivers::DeviceResult;
-use zcore_drivers::utils::EventHandler;
+use crate::scheme::{UartScheme, EventScheme, Scheme};
+use crate::DeviceResult;
+use crate::utils::EventHandler;
 
 register_structs! {
     Pl011UartRegs {
@@ -47,16 +46,6 @@ impl Pl011Uart {
     }
 }
 
-pub fn console_putchar(c: u8) {
-    let uart = Pl011Uart::new(UART_ADDR);
-    uart.putchar(c);
-}
-
-pub fn console_getchar() -> Option<u8> {
-    let uart = Pl011Uart::new(UART_ADDR);
-    uart.getchar()
-}
-
 impl Scheme for Pl011Uart {
     fn name(&self) -> &str {
         "Pl011 ARM series uart"
@@ -93,15 +82,5 @@ impl UartScheme for Pl011Uart {
             self.send(c)?;
         }
         Ok(())
-    }
-}
-
-hal_fn_impl! {
-    impl mod crate::hal_fn::console {
-        fn console_write_early(s: &str) {
-            for c in s.bytes() {
-                console_putchar(c as u8);
-            }
-        }
     }
 }

--- a/kernel-hal/src/bare/arch/aarch64/drivers.rs
+++ b/kernel-hal/src/bare/arch/aarch64/drivers.rs
@@ -1,5 +1,5 @@
 use crate::drivers;
-use super::serial::Pl011Uart;
+use zcore_drivers::uart::Pl011Uart;
 use zcore_drivers::Device;
 use alloc::sync::Arc;
 use crate::imp::config::UART_ADDR;

--- a/kernel-hal/src/bare/arch/aarch64/mod.rs
+++ b/kernel-hal/src/bare/arch/aarch64/mod.rs
@@ -6,11 +6,12 @@ pub mod mem;
 pub mod timer;
 pub mod trap;
 pub mod vm;
-pub mod serial;
 
 use alloc::string::String;
 use core::ops::Range;
 use crate::{mem::phys_to_virt, utils::init_once::InitOnce, PhysAddr};
+
+hal_fn_impl_default!(crate::hal_fn::console);
 
 static INITRD_REGION: InitOnce<Option<Range<PhysAddr>>> = InitOnce::new_with_default(None);
 static CMDLINE: InitOnce<String> = InitOnce::new_with_default(String::new());


### PR DESCRIPTION
原先的串口驱动放在kernel_hal crate下；
为了遵循zcore的代码模块化，现将树莓派的串口驱动放在了drivers crate下面。

Signed-off-by: Wynn <1052209675@qq.com>